### PR TITLE
修正同一个域名，同时设置'A'与'AAAA'解析记录时获取RecordId值错误的问题。

### DIFF
--- a/ddns.php
+++ b/ddns.php
@@ -94,7 +94,7 @@ class MyDDNS
         $prefix = null;
 
         foreach ($recordList as $key => $record) {
-            if ($this->prefix === $record['RR']) {
+            if ($record['Type'] === $this->type && $this->prefix === $record['RR']) {
                 $prefix = $record;
             }
         }


### PR DESCRIPTION
你可以建立一个新的标签版本，支持ipv6的。